### PR TITLE
Use systemctl json output if available

### DIFF
--- a/src/ansible_remote_checks/modules/check_serv.py
+++ b/src/ansible_remote_checks/modules/check_serv.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 from ansible.module_utils.basic import AnsibleModule
+import json
 
 def get_service_info(servicename, module):
   ret={}
@@ -21,16 +22,26 @@ def get_service_info(servicename, module):
     ret[servicename]= values
 
   else:
-    cmd = "systemctl list-units --no-legend --state=failed"
+    cmd = "systemctl list-units --no-legend --state=failed -o json"
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     output, error = process.communicate()
- 
-    for line in output.splitlines():
-      value = line.split()
-      servicename = value[0] 
-      values['message'] = value[2],
-      values['status'] = 3
-      ret[servicename]= values
+
+    # 91 == '[' -> This is a json output
+    if output[0] == 91:
+      failed_json_out = json.loads(output)
+      for json_status in failed_json_out:
+        servicename = json_status['unit']
+        values['message'] = json_status["description"]
+        values['status'] = 3
+        ret[servicename]= values
+    # RHEL8 systems silently ignore "-o json" parse "human status" instead
+    else:
+      for line in output.splitlines():
+        value = line.split()
+        servicename = value[0]
+        values['message'] = value[2],
+        values['status'] = 3
+        ret[servicename]= values
   return ret
 
 def main():


### PR DESCRIPTION
RHEL9 systemctl output format is now emojified, this breaks the old parsing code. But newer versions support json output which will lead to a stable interface to get to the data.