### PR TITLE
check_serv: Handle empty output

### DIFF
--- a/src/ansible_remote_checks/modules/check_serv.py
+++ b/src/ansible_remote_checks/modules/check_serv.py
@@ -27,7 +27,7 @@ def get_service_info(servicename, module):
     output, error = process.communicate()
 
     # 91 == '[' -> This is a json output
-    if output[0] == 91:
+    if output != b'' and output[0] == 91:
       failed_json_out = json.loads(output)
       for json_status in failed_json_out:
         servicename = json_status['unit']


### PR DESCRIPTION
On RHEL8 machine, where systemctl doesn't support json output. An no error setup would return an empty string which leads to an index out of range exception